### PR TITLE
feat: trigger plugin registry update on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           go-version: '1.22'
       - uses: go-semantic-release/action@v1
         with:
-          hooks: goreleaser
+          hooks: goreleaser,plugin-registry-update
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          # PLUGIN_REGISTRY_ADMIN_ACCESS_TOKEN: ${{ secrets.PLUGIN_REGISTRY_ADMIN_ACCESS_TOKEN }}
+          PLUGIN_REGISTRY_ADMIN_ACCESS_TOKEN: ${{ secrets.PLUGIN_REGISTRY_ADMIN_ACCESS_TOKEN }}


### PR DESCRIPTION
This plugin is necessary to trigger registry updates if a new version of the plugin was released.